### PR TITLE
Modification to S3Download() and more...

### DIFF
--- a/filters/summary.py
+++ b/filters/summary.py
@@ -9,6 +9,7 @@ import numpy
 import argparse
 from ipyparallel import Client
 
+
 file_names = []
 downloads = {}
 h5path = None
@@ -22,7 +23,9 @@ def summary(file_path, h5path):
 
     # print("Summary ", file_path, h5path)
 
-    if not h5py.is_hdf5(file_path):
+    if not os.path.exists(file_path):
+        raise IOError(platform.node() + ': File does not exist: ' + file_path)
+    elif not h5py.is_hdf5(file_path):
         raise IOError(platform.node() + ": Not an HDF5 file: " + file_path)
     with h5py.File(file_path, 'r') as f:
         dset = f[h5path]

--- a/filters/summary.py
+++ b/filters/summary.py
@@ -12,8 +12,9 @@ from ipyparallel import Client
 file_names = []
 downloads = {}
 h5path = None
-s3cmd_batch_size=2
+s3cmd_batch_size = 2
 s3_prefix = "s3://"
+
 
 def summary(file_path, h5path):
 
@@ -36,7 +37,8 @@ def summary(file_path, h5path):
         # file name GSSTF_NCEP.3.YYYY.MM.DD.he5
 
         return(file_name, len(v), numpy.min(v), numpy.max(v), numpy.mean(v),
-              numpy.median(v), numpy.std(v))
+               numpy.median(v), numpy.std(v))
+
 
 def startFileDownload():
     print("start file download")
@@ -63,7 +65,8 @@ def startFileDownload():
             else:
                 if subprocesses < s3cmd_batch_size:
                     # start a new download process
-                    p = subprocess.Popen(['s3cmd', 'get', s3_uri, local_filepath])
+                    p = subprocess.Popen(
+                        ['s3cmd', 'get', s3_uri, local_filepath])
                     download["subprocess"] = p
                     subprocesses += 1
                     download["state"] = "INPROGRESS"
@@ -77,6 +80,7 @@ def startFileDownload():
                 download["state"] = "FAILED"
         downloads[filename] = download
 
+
 def checkDownloadComplete():
     print("checkDownloadComplete()")
     in_process_count = 0
@@ -88,21 +92,22 @@ def checkDownloadComplete():
             p = download['subprocess']
             p.poll()
             if p.returncode is None:
-                done = False # still waiting on a download
+                done = False  # still waiting on a download
                 in_process_count += 1
             elif p.returncode < 0:
                 raise IOError("s3cmd failed for " + filename)
             else:
                 download["state"] = "COMPLETE"
         elif download["state"] == "PENDING":
-             queued_items.append(download)
-             done = False
+            queued_items.append(download)
+            done = False
 
     if len(queued_items) > 0:
         for download in queued_items:
             if in_process_count >= s3cmd_batch_size:
-                break # don't start any more subprocesses just yet
-            p = subprocess.Popen(['s3cmd', 'get', download["s3_uri"], download["local_filepath"]])
+                break  # don't start any more subprocesses just yet
+            p = subprocess.Popen(['s3cmd', 'get', download["s3_uri"],
+                                  download["local_filepath"]])
             download["subprocess"] = p
             download["state"] = "INPROGRESS"
             in_process_count += 1
@@ -110,6 +115,7 @@ def checkDownloadComplete():
     if done:
         print("download complete!")
     return done
+
 
 def processFiles():
     print("processFiles()")
@@ -120,7 +126,7 @@ def processFiles():
     for filename in filenames:
         download = downloads[filename]
         print(download)
-        output = summary(download["local_filepath"], h5path )
+        output = summary(download["local_filepath"], h5path)
         return_values.append(output)
     return return_values
 
@@ -140,7 +146,6 @@ def main():
     # example path (for above file):
     # /HDFEOS/GRIDS/NCEP/Data\ Fields/Psea_level
 
-
     args = parser.parse_args()
 
     if not args.filename and not args.input:
@@ -151,7 +156,6 @@ def main():
     global h5path
     h5path = args.path
 
-    files = []
     if args.input:
         with open(args.input) as f:
             for line in f:
@@ -162,7 +166,7 @@ def main():
     else:
         file_names.append(args.filename)
 
-    rc = None # client interface for cluster mode
+    rc = None  # client interface for cluster mode
     dview = None
 
     if args.cluster:
@@ -171,7 +175,7 @@ def main():
             sys.exit("No engines found")
         print(len(rc.ids), "engines")
         dview = rc[:]
-        dview.block = True # use sync
+        dview.block = True  # use sync
         # have engines import packages
         with dview.sync_imports():
             import sys
@@ -214,7 +218,7 @@ def main():
         while not checkDownloadComplete():
             time.sleep(1)  # wait for downloads
 
-        output = processFiles() # just run locally
+        output = processFiles()  # just run locally
 
     for elem in output:
         if type(elem) is list:

--- a/filters/summary.py
+++ b/filters/summary.py
@@ -20,10 +20,10 @@ def summary(file_path, h5path):
 
     file_name = os.path.basename(file_path)
 
-    #print("Summary ", file_path, h5path)
+    # print("Summary ", file_path, h5path)
 
     if not h5py.is_hdf5(file_path):
-        raise IOError("Not an HDF5 file: " + file_path)
+        raise IOError(platform.node() + ": Not an HDF5 file: " + file_path)
     with h5py.File(file_path, 'r') as f:
         dset = f[h5path]
 
@@ -183,6 +183,7 @@ def main():
             import h5py
             import numpy
             import subprocess
+            import platform
         # send the summary method to engines
         dview.push(dict(summary=summary))
         # push the path name
@@ -212,17 +213,23 @@ def main():
 
         print("start processing")
         # run process_files on engines
+        start_time = time.time()
         output = dview.apply(processFiles)
+        end_time = time.time()
+        print('>>>>> runtime: ', end_time - start_time)
     else:
         startFileDownload()
         while not checkDownloadComplete():
             time.sleep(1)  # wait for downloads
 
+        start_time = time.time()
         output = processFiles()  # just run locally
+        end_time = time.time()
+        print('>>>>> runtime: ', end_time - start_time)
 
     for elem in output:
         if type(elem) is list:
-            #output from engines, break out each tuple
+            # output from engines, break out each tuple
             for item in elem:
                 print(item)
         else:

--- a/jobs/ncep_summary.sh
+++ b/jobs/ncep_summary.sh
@@ -2,5 +2,5 @@
 # construct list of s3 uri's to run
 s3cmd ls s3://hdfdata/ncep3/ | grep -v xml | grep he5 | rev | cut -d: -f1 | rev | sed -e 's/^/s3:/' > ncep_files.txt
 cd ../filters/
-python summary.py --input ../jobs/ncep_files.txt --path /HDFEOS/GRIDS/NCEP/Data\ Fields/Tair_2m
+python summary.py -c --input ../jobs/ncep_files.txt --path /HDFEOS/GRIDS/NCEP/Data\ Fields/Tair_2m
 rm ../jobs/ncep_files.txt

--- a/jobs/ncep_summary.sh
+++ b/jobs/ncep_summary.sh
@@ -2,5 +2,5 @@
 # construct list of s3 uri's to run
 s3cmd ls s3://hdfdata/ncep3/ | grep -v xml | grep he5 | rev | cut -d: -f1 | rev | sed -e 's/^/s3:/' > ncep_files.txt
 cd ../filters/
-python summary.py -c --input ../jobs/ncep_files.txt --path /HDFEOS/GRIDS/NCEP/Data\ Fields/Tair_2m
+python summary.py -c whatever --input ../jobs/ncep_files.txt --path /HDFEOS/GRIDS/NCEP/Data\ Fields/Tair_2m
 rm ../jobs/ncep_files.txt

--- a/lib/s3downloader.py
+++ b/lib/s3downloader.py
@@ -203,7 +203,7 @@ class S3Download:
         for s3_uri in keys:
             download = self.downloads[s3_uri]
             state = download["state"]
-            if state in ("PENDING" or "INPROGRESS"):
+            if state in ("PENDING", "INPROGRESS"):
                 download_size += download["size"]
         return download_size
 

--- a/lib/s3downloader.py
+++ b/lib/s3downloader.py
@@ -35,12 +35,12 @@ class S3Download:
     def freespace(self):
         """Get the amount of free space available.
         """
-        return shutil.disk_space(self.s3_dir).free
+        return shutil.disk_usage(self.s3_dir).free
 
     def usedspace(self):
         """Get the number of bytes used in the s3 download directory.
         """
-        return shutil.disk_space(self.s3_dir).used
+        return shutil.disk_usage(self.s3_dir).used
 
     def rmrf(self, pdir):
         """ Remove all files in the given directory.
@@ -84,7 +84,7 @@ class S3Download:
             if line:
                 fields = line.split()
                 # expecting something like:
-                # 2015-10-23 07:44  16631632 # s3://hdfdata/ncep3/GSSTF_NCEP.3.1987.07.01.he5
+                # 2015-10-23 07:44  16631632 s3://hdfdata/ncep3/GSSTF_NCEP.3.1987.07.01.he5
                 if len(fields) == 2 and fields[0] == "DIR":
                     # ignore dirs
                     continue

--- a/lib/s3downloader.py
+++ b/lib/s3downloader.py
@@ -3,104 +3,76 @@ import subprocess
 import os
 import time
 import logging
- 
+import shutil
+
 
 class S3Download:
-     
+
     def __init__(self):
         self.home_dir = os.environ["HOME"]
         self.log = logging.getLogger("s3download")
         self.log.setLevel(logging.INFO)
-        handler = logging.FileHandler(os.path.join(self.home_dir, "s3download.log"))
+        handler = logging.FileHandler(os.path.join(self.home_dir,
+                                      "s3download.log"))
         self.log.addHandler(handler)
         self.downloads = {}
-        
+
         self.s3_prefix = "s3://"
-        self.s3_dir = os.environ["S3_CACHE_DIR"]
         self.s3cmd_batch_size = 2
-        
-        if self.s3_dir is None:
-            raise IOError("S3_CACHE_DIR environment variable not set")
-         
-        self.log.info("s3_dir: " + self.s3_dir)
+
+        # Hardcode the destination for downloaded files
+        self.s3_dir = '/mnt'
         if not os.path.isdir(self.s3_dir):
-            raise IOError(self.s3_dir, ": directory does not exist")
-        
-            
+            raise IOError(self.s3_dir + ": directory does not exist")
+
+        # Make sure the s3_dir is owned by this process' uid...
+        if os.stat(self.s3_dir).st_uid != os.getuid():
+            subprocess.check_call(
+                ['sudo', 'chown', '-R', 'ubuntu:ubuntu', self.s3_dir])
+
+        self.log.info("s3_dir: " + self.s3_dir)
+
     def freespace(self):
-        """Get the amount of freespace available.
+        """Get the amount of free space available.
         """
-        
-        df = subprocess.Popen(["df", self.s3_dir], stdout=subprocess.PIPE)
-        output = df.communicate()[0]
-        text = output.decode("utf-8")  # convert to string
-        index = text.index('\n')
-        if index < 0:
-            raise IOError("unexpected output of df")
-        text = text[(index+1):]
-        fields = text.split()
-        if len(fields) != 6:
-            raise IOError("unexpected output of df")
-        return int(fields[3]) 
-        
+        return shutil.disk_space(self.s3_dir).free
+
     def usedspace(self):
         """Get the number of bytes used in the s3 download directory.
         """
-        du = subprocess.Popen(["du", self.s3_dir], stdout=subprocess.PIPE)
-        output = du.communicate()[0]
-        text = output.decode("utf-8")  # convert to string
-        lines = text.split('\n')
-        if len(lines) == 0:
-            raise IOError("unexpected output of du")
-        last_line = None
-        for line in lines:
-            line = line.strip()
-            if line:
-                last_line = line    
-        
-        fields = last_line.split()
-         
-        if len(fields) != 2:
-            raise IOError("unexpected output of du")
-        return int(fields[0])
-        
+        return shutil.disk_space(self.s3_dir).used
+
     def rmrf(self, pdir):
         """ Remove all files in the given directory.
            caution recursive delete - use with care!
+
         :arg str pdir: directory to remove files from
         """
-        self.log.info("rmrf()")
-        files = []
+        self.log.info("rmrf({})".format(pdir))
         if pdir is None:
-            raise IOError("clear called with non-valid path")
+            raise IOError("rmrf() called with non-valid path")
         if not os.path.isdir(pdir):
-            raise IOError("clear called with non-directory path")
+            raise IOError("rmrf() called with non-directory path")
         # sanity check, so we don't got erasing files outside the s3_dir...
         if not pdir.startswith(self.s3_dir):
-            raise IOError("Invalid path", pdir)
-            
-        for f in os.listdir(pdir):
-            path = os.path.join(pdir, f)
-            if os.path.isdir(path):
-                self.rmrf(pdir=path)
-                self.log.info("rmdir:" + path)
-                os.rmdir(path)
-            else:
-                self.log.info("rm: " + path)
-                os.remove(path)
-                
+            raise IOError("Invalid path: " + pdir)
+
+        shutil.rmtree(pdir)
+
     def clear(self):
         """ Remove files from s3 download directory, clears download queue
         """
         self.log.info("clear")
         self.rmrf(self.s3_dir)
         self.downloads.clear()
-        
+
     def s3cmdls(self, s3uri):
         """ List s3 objects
+
         :arg str s3uri: s3 uri
         """
-        s3cmd = subprocess.Popen(["s3cmd", "ls", s3uri], stdout=subprocess.PIPE)
+        s3cmd = subprocess.Popen(["s3cmd", "ls", s3uri],
+                                 stdout=subprocess.PIPE)
         output = s3cmd.communicate()[0]
         text = output.decode("utf-8")  # convert to string
         lines = text.split('\n')
@@ -112,32 +84,30 @@ class S3Download:
             if line:
                 fields = line.split()
                 # expecting something like:
-                # 2015-10-23 07:44  16631632   s3://hdfdata/ncep3/GSSTF_NCEP.3.1987.07.01.he5
+                # 2015-10-23 07:44  16631632 # s3://hdfdata/ncep3/GSSTF_NCEP.3.1987.07.01.he5
                 if len(fields) == 2 and fields[0] == "DIR":
                     # ignore dirs
                     continue
                 if len(fields) != 4:
-                    raise IOError("Unexpected output from s3cmd: " + line)  
+                    raise IOError("Unexpected output from s3cmd: " + line)
                 s3ls_output = (fields[0], fields[1], int(fields[2]), fields[3])
-                s3ls.append(s3ls_output) 
-        
-        
+                s3ls.append(s3ls_output)
+
         return s3ls
-        
-        
+
     def addFiles(self, s3uris):
         """add objects to download list.
-        :arg list s3uris can be folder path, or list of object uri's
+
+        :arg list s3uris: can be folder path, or list of object uri's
         """
         if type(s3uris) is str:
             # convert to one element list
-            s3_list = (s3uris,)
-            s3uris = s3_list
-        
+            s3uris = [s3uris]
+
         for s3_uri in s3uris:
             self.log.info("addFiles: " + s3_uri)
             if not s3_uri.startswith(self.s3_prefix):
-                raise IOError("Invalid s3 uri")
+                raise IOError("Invalid s3 uri: %s" % s3_uri)
             s3ls_out = self.s3cmdls(s3_uri)
             if len(s3ls_out) == 0:
                 raise IOError("no s3 objects found for " + s3_uri)
@@ -150,50 +120,50 @@ class S3Download:
                 s3_path = s3_item[len(self.s3_prefix):]
                 print("s3_path", s3_path)
                 local_filepath = os.path.join(self.s3_dir, s3_path)
-            
+
                 download = {}
                 download['s3_uri'] = s3_item
                 download['s3_date'] = output[0]
                 download['s3_time'] = output[1]
                 download['size'] = output[2]
-                download["local_filepath"] = local_filepath  
-                
+                download["local_filepath"] = local_filepath
+
                 if os.path.exists(local_filepath):
-                    # todo, check that the s3 object is the same as local copy  
-                    download["state"] = 'COMPLETE'  
-                else: 
+                    # todo, check that the s3 object is the same as local copy
+                    download["state"] = 'COMPLETE'
+                else:
                     download['state'] = 'PENDING'
-                
+
                 self.downloads[s3_item] = download
-                
+
     def update(self):
         """check status of downloads and start more subprocesses as needed.
         :return int number of pending/inprogress downloads
         """
         self.log.info("update")
         print("update!")
-        
+
         keys = list(self.downloads.keys())
         keys.sort()
         print("num items " + str(len(keys)))
         # count number of pending/inprocess items
         pending_count = 0
         inprocess_count = 0
-        
+
         for s3_uri in keys:
             print(s3_uri)
             download = self.downloads[s3_uri]
-            
+
             print(download)
             state = download["state"]
             s3_uri = download["s3_uri"]
             local_filepath = download["local_filepath"]
-            
+
             if state == 'INPROGRESS':
                 p = download['subprocess']
                 p.poll()
                 if p.returncode is None:
-                    inprocess_count += 1 # still waiting on a download
+                    inprocess_count += 1  # still waiting on a download
                 elif p.returncode < 0:
                     self.log.error("s3cmd failed for " + s3_uri)
                     download['subprocess'] = None
@@ -204,11 +174,12 @@ class S3Download:
                     download['subprocess'] = None
                     download["state"] = 'COMPLETE'
                     download["rc"] = 0
-            elif state == 'PENDING': 
-                print("pending")      
+            elif state == 'PENDING':
+                print("pending")
                 if inprocess_count < self.s3cmd_batch_size:
                     # start a new download process
-                    p = subprocess.Popen(['s3cmd', 'get', s3_uri, local_filepath])
+                    p = subprocess.Popen(
+                        ['s3cmd', 'get', s3_uri, local_filepath])
                     download["subprocess"] = p
                     inprocess_count += 1
                     download["state"] = "INPROGRESS"
@@ -217,25 +188,25 @@ class S3Download:
         # return count of pending and inprogress items
         # 0 -> download COMPLETE
         return pending_count + inprocess_count
-    
+
     def downloadsize(self):
         """Get the number of bytes to be downloaded.
         """
         keys = list(self.downloads.keys())
         keys.sort()
-        
+
         # count number of pending/inprocess items
         download_size = 0
-        
+
         for s3_uri in keys:
             download = self.downloads[s3_uri]
             state = download["state"]
-            if state in ("PENDING" or "INPROGRESS"): 
+            if state in ("PENDING" or "INPROGRESS"):
                 download_size += download["size"]
         return download_size
-                    
+
     def start(self):
-        """Start download.  Return exception if the amount of freespace is 
+        """Start download.  Return exception if the amount of freespace is
         not sufficient to store objects in download queue.
         """
         # verify that we have enough free space for the download
@@ -245,11 +216,11 @@ class S3Download:
             msg = "not enough free space to download: " + str(download_size)
             msg += ", " + str(freespace) + " available"
             self.log.info(msg)
-            raise IOError(msg)  
-        
+            raise IOError(msg)
+
         count = self.update()
-        return count                       
-                     
+        return count
+
     def dump(self):
         """ Return state of download queue.
         """
@@ -258,12 +229,5 @@ class S3Download:
         s3_uris.sort()
         for s3_uri in s3_uris:
             download = self.downloads[s3_uri]
-            output.append((s3_uri, download['state'] ))
+            output.append((s3_uri, download['state']))
         return output
-         
-     
-
-    
-     
-     
-  

--- a/lib/s3downloader.py
+++ b/lib/s3downloader.py
@@ -212,7 +212,7 @@ class S3Download:
         not sufficient to store objects in download queue.
         """
         # verify that we have enough free space for the download
-        freespace = self.freespace()
+        freespace = self.freespace
         download_size = self.downloadsize()
         if download_size > freespace:
             msg = "not enough free space to download: " + str(download_size)

--- a/lib/s3downloader.py
+++ b/lib/s3downloader.py
@@ -32,11 +32,13 @@ class S3Download:
 
         self.log.info("s3_dir: " + self.s3_dir)
 
+    @property
     def freespace(self):
         """Get the amount of free space available.
         """
         return shutil.disk_usage(self.s3_dir).free
 
+    @property
     def usedspace(self):
         """Get the number of bytes used in the s3 download directory.
         """


### PR DESCRIPTION
This branch started as my modifications to the S3Download() class but now holds more than just that. As for the S3Download() mods:

* Hardcoded the destination for downloaded files to `/mnt`. It also does `chown ubuntu:ubuntu` when the class is instantiated.
* The methods `usedspace()` and `freespace()` are turned to properties and use the `shutil.disk_usage()` to collect information.

Other notable changes so far:

* `summary.py` checks whether HDF5 file exists first prior to checking if the same file is valid HDF5. Error messages include node name (using `platform.node()`) so now one can ssh into that VM and examine the error cause.
* `ncep_summary.sh` runs `summary.py` in the cluster mode.